### PR TITLE
gofmt formatting, add openbsd and plan9 support

### DIFF
--- a/loginshell.go
+++ b/loginshell.go
@@ -1,62 +1,84 @@
 package loginshell
 
 import (
-    "runtime"
-    "fmt"
-    "os"
-    "os/exec"
-    "os/user"
-    "errors"
-    "regexp"
-    "strings"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"regexp"
+	"runtime"
+	"strings"
 )
 
 func Shell() (string, error) {
-    switch runtime.GOOS {
-        case "linux":
-          return LinuxShell()
-        case "darwin":
-          return DarwinShell()
-        case "windows":
-          return WindowsShell()
-    }
-    return "", errors.New("Undefined GOOS: " + runtime.GOOS)
+	switch runtime.GOOS {
+	case "plan9":
+		return Plan9Shell()
+	case "linux":
+		return NixShell()
+	case "openbsd":
+		return NixShell()
+	case "freebsd":
+		return NixShell()
+	case "darwin":
+		return DarwinShell()
+	case "windows":
+		return WindowsShell()
+	}
+
+	return "", errors.New("Undefined GOOS: " + runtime.GOOS)
+}
+
+func Plan9Shell() (string, error) {
+	if _, err := os.Stat("/dev/osversion"); err != nil {
+		if os.IsNotExist(err) {
+			return "", err
+		} else {
+			return "", errors.New("/dev/osversion check failed")
+		}
+	}
+
+	return "/bin/rc", nil
 }
 
 func WindowsShell() (string, error) {
-    consoleApp := os.Getenv("COMSPEC")
-    if consoleApp == "" {
-        consoleApp = "cmd.exe"
-    }
-    return consoleApp, nil
+	consoleApp := os.Getenv("COMSPEC")
+	if consoleApp == "" {
+		consoleApp = "cmd.exe"
+	}
+
+	return consoleApp, nil
 }
 
-func LinuxShell() (string, error) {
-    user, err := user.Current()
-    if err != nil {
-        return "", err
-    }
-    out, err := exec.Command("getent", "passwd", user.Uid).Output()
-    if err != nil {
-        return "", err
-    }
+func NixShell() (string, error) {
+	user, err := user.Current()
+	if err != nil {
+		return "", err
+	}
 
-    ent := strings.Split(strings.TrimSuffix(string(out), "\n"), ":")
-    return ent[6], nil
+	out, err := exec.Command("getent", "passwd", user.Uid).Output()
+	if err != nil {
+		return "", err
+	}
+
+	ent := strings.Split(strings.TrimSuffix(string(out), "\n"), ":")
+	return ent[6], nil
 }
 
 func DarwinShell() (string, error) {
-    dir := "Local/Default/Users/" + os.Getenv("USER")
-    out, err := exec.Command("dscl", "localhost", "-read", dir, "UserShell").Output()
-    if err != nil {
-        return "", err
-    }
+	dir := "Local/Default/Users/" + os.Getenv("USER")
+	out, err := exec.Command("dscl", "localhost", "-read", dir, "UserShell").Output()
+	if err != nil {
+		return "", err
+	}
 
-    re := regexp.MustCompile("UserShell: (/[^ ]+)\n")
-    matched := re.FindStringSubmatch(string(out))
-    shell := matched[1]
-    if shell == "" {
-        return "", errors.New(fmt.Sprintf("Invalid output: %s", string(out)))
-    }
-    return shell, nil
+	re := regexp.MustCompile("UserShell: (/[^ ]+)\n")
+	matched := re.FindStringSubmatch(string(out))
+	shell := matched[1]
+	if shell == "" {
+		return "", errors.New(fmt.Sprintf("Invalid output: %s", string(out)))
+	}
+
+	return shell, nil
 }


### PR DESCRIPTION
* `loginshell.go` was formatted using `gofmt`
* Add a `Plan9Shell` function when running on Plan 9/derivatives
* Rename `LinuxShell` to `NixShell` since the `getent` method of getting the current user's shell works well on both OpenBSD and FreeBSD. I haven't tested on others.